### PR TITLE
Potential fix for code scanning alert no. 18: Database query built from user-controlled sources

### DIFF
--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -386,7 +386,7 @@ const resetPassword = asyncHandler(async (req, res) => {
   }
 
   const user = await User.findOne({
-    _id: id,
+    _id: { $eq: id },
   });
 
   if (!user) {


### PR DESCRIPTION
Potential fix for [https://github.com/BitForge-Org/covelent_backend/security/code-scanning/18](https://github.com/BitForge-Org/covelent_backend/security/code-scanning/18)

To fix the problem, we should ensure that the value for `_id` in the query passed to `User.findOne` can only ever be interpreted as a literal value and not as a query operator/object. There are two widely accepted, secure options:

1. Use the `$eq` operator: Change `{ _id: id }` to `{ _id: { $eq: id } }`. This forces MongoDB to treat `id` as a literal match.
2. Validate type: Ensure `id` is a string (or ObjectId), and reject if it is an object or another value type (e.g., via `typeof id === "string"` check).

For maintainability and minimal code change, using the `$eq` operator is ideal here. The edit is required in the `resetPassword` handler in `src/controllers/auth.controller.js`, at the query on lines 388-390. No additional imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
