### PR TITLE
Potential fix for code scanning alert no. 17: Database query built from user-controlled sources

### DIFF
--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -359,9 +359,12 @@ const verifyOtp = asyncHandler(async (req, res) => {
   if (!otp) {
     throw new ApiError(400, "OTP is required");
   }
+  if (typeof otp !== "string") {
+    throw new ApiError(400, "Invalid OTP type");
+  }
 
   const user = await User.findOne({
-    resetPasswordToken: otp,
+    resetPasswordToken: { $eq: otp },
     resetPasswordExpires: { $gt: Date.now() },
     isActive: true,
     isVerified: true,


### PR DESCRIPTION
Potential fix for [https://github.com/BitForge-Org/covelent_backend/security/code-scanning/17](https://github.com/BitForge-Org/covelent_backend/security/code-scanning/17)

To fix the vulnerability, ensure that the untrusted user input (`otp`) is interpreted by MongoDB as a literal value and not a query object. The recommended way is to wrap the value in MongoDB's `$eq` operator to prevent possible NoSQL injection. Alternatively (and additionally), validate the type of `otp` – typically, OTPs are strings or numbers, so enforcing a type check (e.g., `typeof otp === "string"`) further reduces risk. The minimal, robust fix is to change the query on line 363 to use `{resetPasswordToken: { $eq: otp }, ...}` and optionally throw an error if `otp` is not a string (add a runtime check before the query).

The required changes:
- In file `src/controllers/auth.controller.js`, function `verifyOtp`, change the query in the `User.findOne()` call (line 363–368) to use `{ resetPasswordToken: { $eq: otp }, ... }`.
- Optionally, add a check prior to the query: if `typeof otp !== "string"` or if it fails your business validation rules, throw an error as on lines 360–361.

No new library imports are necessary; only the query object construction is changed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
