### PR TITLE
Potential fix for code scanning alert no. 16: Database query built from user-controlled sources

### DIFF
--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -296,8 +296,9 @@ const refreshAccessToken = asyncHandler(async (req, res) => {
 const forgotPassword = asyncHandler(async (req, res) => {
   const { email } = req.body;
   if (!email) throw new ApiError(400, "Email is required");
+  if (typeof email !== "string") throw new ApiError(400, "Invalid email format");
 
-  const user = await User.findOne({ email });
+  const user = await User.findOne({ email: { $eq: email } });
   if (!user) throw new ApiError(404, "User with this email does not exist");
   if (!user.isActive || !user.isVerified)
     throw new ApiError(401, "User account is not active or not verified");


### PR DESCRIPTION
Potential fix for [https://github.com/BitForge-Org/covelent_backend/security/code-scanning/16](https://github.com/BitForge-Org/covelent_backend/security/code-scanning/16)

To mitigate NoSQL injection, the best solution is to ensure that the `email` field is strictly interpreted as a literal string value. You can do this by either (1) validating that `email` is a string before passing it to the query, or (2) using the `$eq` operator in the query object to ensure that user data cannot be used to inject query operators. The canonical fix (as suggested by CodeQL and MongoDB documentation) is to use the `$eq` operator: `User.findOne({ email: { $eq: email } })`. Optionally, you can also explicitly check the type of `email` and reject invalid requests early. Edit line 300 in `src/controllers/auth.controller.js` to use the `$eq` operator for safety.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
