### PR TITLE
Potential fix for code scanning alert no. 43: Use of externally-controlled format string

### DIFF
--- a/src/utils/cloudinary.js
+++ b/src/utils/cloudinary.js
@@ -42,7 +42,7 @@ const uploadOnCloudinary = async (localFilePath, folder) => {
       try {
         fs.unlinkSync(absoluteFilePath); // remove locally saved temp file as upload failed
       } catch (e) {
-        console.warn(`Failed to delete unsafe or missing file: ${absoluteFilePath}`, e);
+        console.warn("Failed to delete unsafe or missing file:", absoluteFilePath, e);
       }
     } else {
       console.warn(`Unsafe file path detected for deletion (error branch): ${absoluteFilePath}`);


### PR DESCRIPTION
Potential fix for [https://github.com/BitForge-Org/covelent_backend/security/code-scanning/43](https://github.com/BitForge-Org/covelent_backend/security/code-scanning/43)

To fix the issue, the log message string passed as the first argument to `console.warn` must not be influenced by user input in a way that would allow for format string injection. Instead of using a template literal or concatenation in the first argument (where the string could contain user-controlled format specifiers), we pass a static string as the first parameter and the potentially unsafe value (`absoluteFilePath`) as a separate argument. This prevents any unintended format string substitution, maintains the integrity of the log message, and follows best practices.

**What to change:**
- In `src/utils/cloudinary.js`, on line 45, replace:
  ```js
  console.warn(`Failed to delete unsafe or missing file: ${absoluteFilePath}`, e);
  ```
  with
  ```js
  console.warn("Failed to delete unsafe or missing file:", absoluteFilePath, e);
  ```
- No additional imports, methods, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
