### PR TITLE
Potential fix for code scanning alert no. 45: Use of externally-controlled format string

### DIFF
--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -46,7 +46,7 @@ function cleanupUploadedFiles(filePaths) {
         fs.unlinkSync(safeFilePath);
         console.log(`[CLEANUP] Removed file: ${safeFilePath}`);
       } catch (error) {
-        console.error(`[CLEANUP] Failed to remove file ${safeFilePath}:`, error);
+        console.error("[CLEANUP] Failed to remove file: %s", safeFilePath, error);
       }
     } else if (filePath) {
       console.warn(`[SECURITY] Refused to unlink file outside upload dir: ${filePath}`);


### PR DESCRIPTION
Potential fix for [https://github.com/BitForge-Org/covelent_backend/security/code-scanning/45](https://github.com/BitForge-Org/covelent_backend/security/code-scanning/45)

To fix this problem, we should avoid embedding user-controlled or potentially tainted values directly in template literals (format strings sent to logging functions). The best practice is to use static format strings and pass untrusted data as separate arguments to the logging function (`console.error`), letting the logging function handle string conversion.  
Specifically, in `cleanupUploadedFiles`, instead of `` console.error(`[CLEANUP] Failed to remove file ${safeFilePath}:`, error); ``, we should use a static string with a substitution placeholder, like:
`` console.error("[CLEANUP] Failed to remove file: %s", safeFilePath, error); ``  
No additional imports are required, and the fix is entirely local to the `cleanupUploadedFiles` function in src/controllers/auth.controller.js.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
